### PR TITLE
Возможность поиска нескольких значений по одному ключу

### DIFF
--- a/src/caller.js
+++ b/src/caller.js
@@ -28,8 +28,15 @@ export class LZTApiCaller {
 		
 		if(method === 'GET' || method === 'PUT' || method === 'DELETE') {
 			for(const key of Object.keys(params))
-				if(params[key] !== undefined)
-					url.searchParams.set(key, params[key])
+				if(params[key] !== undefined) {
+					if (Array.isArray(params[key])) {
+						for (let i = 0; i < params[key].length; i++) {
+							url.searchParams.set(`${key}[${i}]`, params[key][i]);
+						}
+					} else {
+						url.searchParams.set(key, params[key])
+					}
+				}
 		} else {
 			options.body = new FormData()
 			for(const key of Object.keys(params))


### PR DESCRIPTION
Библиотека наотрез отказывается принимать несколько значений по одному ключу. Например:
```
const results = await api.market.search({
    categoryName: 'fortnite',
    skin: ['761_athena_commando_m_cyclonespace', '209_athena_commando_m_footballdudec'],
});
```
В URL идет либо последний скин, либо весь массив целиком. Оба варианта не позволяют нормально искать нужные аккаунты.